### PR TITLE
bpf: chacha_block __always_inline for kernel 6.17+ verifier compat

### DIFF
--- a/src/bpf/gut_common.h
+++ b/src/bpf/gut_common.h
@@ -324,8 +324,13 @@ struct
  * Working state is kept entirely in ks[] (the caller-provided buffer, which
  * lives in the scratch per-CPU map) so that chacha_block itself has zero
  * u32 local variables on the BPF 512-byte stack.  The initial state is
- * re-read from the chacha_init pointer for the final addition. */
-static __attribute__((noinline)) void chacha_block(__u32 ks[16],
+ * re-read from the chacha_init pointer for the final addition.
+ *
+ * __always_inline is required on kernel 6.17+ where the BPF verifier
+ * rejects noinline helpers that receive map-value pointers as arguments
+ * (ks[] points into scratch_map).  Since chacha_block has zero stack
+ * locals of its own the inlining cost is just code size, not stack. */
+static __always_inline void chacha_block(__u32 ks[16],
                                                    const __u32 chacha_init[12],
                                                    __u32 counter, __u32 nonce)
 {


### PR DESCRIPTION
## Problem

On kernel 6.17+ the BPF verifier rejects `noinline` helpers that receive map-value pointers as arguments. `chacha_block` takes `ks[]` which points into the per-CPU `scratch_map`, triggering:

```
arg#0 pointer type CONST_PTR_TO_MAP_VALUE must point to scalar,
or struct with scalar
```

This prevents gutd from loading its BPF programs on kernel 6.17+ (e.g. Ubuntu 25.04).

## Fix

Switch `chacha_block` from `__attribute__((noinline))` to `__always_inline`. Since `chacha_block` keeps all working state in the caller-provided `ks[]` buffer and declares zero local variables, inlining has no stack cost — only code size increases.

## Testing

`sudo bash tests/integration-wg.sh` results on Azure Standard_B2s (kernel 6.17.0-1010-azure):

| Mode | Throughput | Packet Loss | Anti-probe |
|------|-----------|-------------|------------|
| WG baseline | 2387 Mbps | — | — |
| gutd eBPF | 1180 Mbps | 0% | QUIC VN PASS |
| gutd userspace | 566 Mbps | 0% | — |

Also verified no regression on kernel 5.15 (Ubuntu 22.04).