### PR TITLE
Fix GUT TC/XDP WireGuard transport-data restoration

### DIFF
--- a/src/bpf/tc_gut_egress.bpf.c
+++ b/src/bpf/tc_gut_egress.bpf.c
@@ -475,7 +475,9 @@ int gut_egress(struct __sk_buff *skb)
     __u32 room = outer_hdr_len;
 #endif
 
-    if (bpf_skb_adjust_room(skb, room, BPF_ADJ_ROOM_MAC, 0) < 0)
+    __u64 adj_flags = BPF_F_ADJ_ROOM_ENCAP_L4_UDP | BPF_F_ADJ_ROOM_FIXED_GSO;
+    adj_flags |= (ipver == 6) ? BPF_F_ADJ_ROOM_ENCAP_L3_IPV6 : BPF_F_ADJ_ROOM_ENCAP_L3_IPV4;
+    if (bpf_skb_adjust_room(skb, room, BPF_ADJ_ROOM_MAC, adj_flags) < 0)
         return TC_ACT_OK;
 
     if (bpf_skb_pull_data(skb, skb->len) < 0)
@@ -596,7 +598,17 @@ int gut_egress(struct __sk_buff *skb)
     }
 #elif defined(GUT_MODE_GUT)
     __u8 *quic = (__u8 *)data + new_quic_off;
+    __u8 gut_type4_len_byte = 0;
     write_gut_header(quic, data_end, ppn, enc_ports, pad_len);
+    if (wg_type == 4)
+    {
+        if (wg_len < WG_MIN_PACKET || ((wg_len - WG_MIN_PACKET) & 0x0F))
+            return TC_ACT_OK;
+        __u32 len_code = (wg_len - WG_MIN_PACKET) >> 4;
+        if (len_code > 255)
+            return TC_ACT_OK;
+        gut_type4_len_byte = (__u8)len_code;
+    }
 #else  /* GUT_MODE_QUIC */
     __u8 *quic = (__u8 *)data + new_quic_off;
     if (outer_hdr_len == GUT_QUIC_SHORT_HEADER_SIZE)
@@ -696,20 +708,12 @@ int gut_egress(struct __sk_buff *skb)
         __u64 ip_csum = bpf_csum_diff(0, 0, (__be32 *)iph, sizeof(struct iphdr), 0);
         iph->check = csum_fold(ip_csum);
 
-        /* Kernel's udp_set_csum() forces skb->ip_summed = CHECKSUM_PARTIAL
-         * for locally-generated UDP-encapsulated traffic (WireGuard). In that
-         * mode the NIC offload (or skb_checksum_help() when offload is off)
-         * finalises the checksum by adding the payload sum. We must therefore
-         * write ONLY the pseudo-header fold into udph->check (matching what
-         * udp_set_csum() does). Writing the full checksum here causes HW
-         * offload to add the payload sum a second time and corrupts the
-         * value on the wire. */
+        /* IPv4 UDP checksums are optional.  The encapsulated skb can carry stale
+         * CHECKSUM_PARTIAL metadata from the inner WireGuard UDP packet, which
+         * makes the outer checksum field wrong on some VM/NAT paths.  Emit an
+         * explicit zero checksum for the final outer IPv4 UDP packet instead of
+         * relying on skb checksum metadata/offload state. */
         udph->check = 0;
-        __u32 pseudo = 0;
-        pseudo = bpf_csum_diff(0, 0, &iph->saddr, 8, pseudo); // saddr and daddr are contiguous
-        __u32 ph = bpf_htonl((IPPROTO_UDP << 16) | bpf_ntohs(udph->len));
-        pseudo = bpf_csum_diff(0, 0, &ph, 4, pseudo);
-        udph->check = (__u16)~csum_fold(pseudo); // pseudo-only; NIC/kernel adds payload
     }
     else if (ipver == 6)
     {
@@ -780,6 +784,21 @@ int gut_egress(struct __sk_buff *skb)
     __builtin_memcpy(eth->h_dest, cfg->dst_mac, 6);
     __builtin_memcpy(eth->h_source, cfg->src_mac, 6);
 
+#if defined(GUT_MODE_GUT)
+    if (wg_type == 4)
+    {
+        __u8 gut_hdr[GUT_HEADER_SIZE];
+        __builtin_memcpy(gut_hdr + 0, &ppn, 4);
+        __builtin_memcpy(gut_hdr + 4, &enc_ports, 4);
+        gut_hdr[8] = gut_type4_len_byte;
+        gut_hdr[9] = (pad_len > 0) ? (0x40 | ((__u8)(pad_len - 1) & 0x3F)) : 0x00;
+        if (bpf_skb_store_bytes(skb, new_quic_off, gut_hdr, GUT_HEADER_SIZE, 0) < 0)
+        {
+            return TC_ACT_OK;
+        }
+    }
+#endif
+
     if (stats)
     {
         stats->packets_processed++;
@@ -787,7 +806,24 @@ int gut_egress(struct __sk_buff *skb)
         stats->bytes_processed += (__u64)skb->len;
     }
 
-    bpf_debug("TC egress: wg_type=%d outer_hdr=%d pad=%d port=%d", wg_type, outer_hdr_len, pad_len, tunnel_port);
+
+#if defined(GUT_MODE_GUT)
+    if (wg_type == 4) {
+        __u8 emit_gut_hdr[GUT_HEADER_SIZE];
+        __builtin_memcpy(emit_gut_hdr + 0, &ppn, 4);
+        __builtin_memcpy(emit_gut_hdr + 4, &enc_ports, 4);
+        emit_gut_hdr[8] = gut_type4_len_byte;
+        emit_gut_hdr[9] = (pad_len > 0) ? (0x40 | ((__u8)(pad_len - 1) & 0x3F)) : 0x00;
+
+
+        if (bpf_skb_store_bytes(skb, new_quic_off, emit_gut_hdr, GUT_HEADER_SIZE, 0) < 0) {
+            return TC_ACT_OK;
+        }
+
+
+    }
+#endif
+bpf_debug("TC egress: wg_type=%d outer_hdr=%d pad=%d port=%d", wg_type, outer_hdr_len, pad_len, tunnel_port);
     return bpf_redirect(cfg->egress_ifindex, 0);
 }
 
@@ -893,7 +929,10 @@ int gut_egress_sip_signal(struct __sk_buff *skb)
     }
 
     /* ── Adjust packet size and shift IP/UDP headers ── */
-    if (bpf_skb_adjust_room(skb, room, BPF_ADJ_ROOM_MAC, 0) < 0)
+    __u64 adj_flags = BPF_F_ADJ_ROOM_ENCAP_L4_UDP | BPF_F_ADJ_ROOM_FIXED_GSO;
+    adj_flags |= (ipver == 6) ? BPF_F_ADJ_ROOM_ENCAP_L3_IPV6 : BPF_F_ADJ_ROOM_ENCAP_L3_IPV4;
+
+    if (bpf_skb_adjust_room(skb, room, BPF_ADJ_ROOM_MAC, adj_flags) < 0)
         return TC_ACT_OK;
 
     if (bpf_skb_pull_data(skb, skb->len) < 0)

--- a/src/bpf/xdp_gut_ingress.bpf.c
+++ b/src/bpf/xdp_gut_ingress.bpf.c
@@ -754,6 +754,57 @@ static __always_inline int gut_xdp_core(struct xdp_md *ctx, struct gut_config *c
     }
 #endif
 
+#if defined(GUT_MODE_GUT)
+    __u32 restored_wg_len = wg_len;
+    if (wg_type == 1)
+    {
+        if (wg_len < 148)
+            return -1;
+        restored_wg_len = 148;
+    }
+    else if (wg_type == 2)
+    {
+        if (wg_len < 92)
+            return -1;
+        restored_wg_len = 92;
+    }
+    else if (wg_type == 3)
+    {
+        if (wg_len < 64)
+            return -1;
+        restored_wg_len = 64;
+    }
+    else if (wg_type == 4) {
+        /* GUT type4: infer restored WireGuard transport length from wire length.
+         * Do not trust quic[8] / quic[9] on the dynamic-peer reverse path: v12
+         * proved TC can read byte8=0x06 before redirect while the emitted eth0
+         * packet still has random bytes at GUT header positions 8/9.  The wire
+         * payload length is still stable. WireGuard transport-data packets are
+         * aligned as 32 + 16*N; TC adds only ballast after the encrypted WG
+         * packet.  Therefore strip ballast by rounding the post-GUT payload
+         * length down to the nearest WG type4-aligned size.
+         */
+        if (wg_len < WG_MIN_PACKET) return -2;
+        __u32 inferred_delta = wg_len - WG_MIN_PACKET;
+        inferred_delta &= ~0x0FU;
+        restored_wg_len = WG_MIN_PACKET + inferred_delta;
+        if (restored_wg_len < WG_MIN_PACKET || restored_wg_len > wg_len) return -2;
+        if (wg_len - restored_wg_len > 63) return -2;
+    }
+    else
+    {
+        return -1;
+    }
+
+    if (restored_wg_len > wg_len)
+        return -1;
+
+    __u32 tail_total = wg_len - restored_wg_len;
+    if (tail_total > 63)
+        return -1;
+
+    __u16 new_udp_len = (__u16)(sizeof(struct udphdr) + restored_wg_len);
+#else
     if (ballast_len > 63 || ballast_len > wg_len)
         return -1;
 
@@ -761,9 +812,21 @@ static __always_inline int gut_xdp_core(struct xdp_md *ctx, struct gut_config *c
     if (wg_len < tail_total || wg_len - tail_total < WG_MIN_PACKET)
         return -1;
 
-    // "нам ничего не надо считать от конца пакета!!" -> we removed meta extraction.
-
     __u16 new_udp_len = (__u16)(udp_len - tail_total - outer_hdr_len);
+#endif
+    if (ipver == 4)
+    {
+        struct iphdr *iph_check = (void *)((__u8 *)data + ip_off);
+        if ((void *)(iph_check + 1) > data_end)
+            return -1;
+    }
+    else
+    {
+        struct ipv6hdr *ip6h_check = (void *)((__u8 *)data + ip_off);
+        if ((void *)(ip6h_check + 1) > data_end)
+            return -1;
+    }
+
     udph->len = bpf_htons(new_udp_len);
     udph->check = 0;
 
@@ -1322,6 +1385,9 @@ int xdp_gut_ingress(struct xdp_md *ctx)
     int rc = gut_xdp_core(ctx, cfg);
     if (rc != 0)
     {
+        if (rc == -2)
+            return XDP_DROP;
+
 #if defined(GUT_MODE_QUIC)
         /* QUIC mode: tail-call to probe handler to stay within verifier
          * budget on kernel ≤6.2.  On tail-call failure, fall through. */


### PR DESCRIPTION
## Summary

This change fixes bidirectional GUT-mode TC/XDP processing for kernel-mode WireGuard relay traffic.

WireGuard handshake packets and transport-data packets require different restoration logic:

- handshake-init: fixed 148-byte WireGuard payload
- handshake-response: fixed 92-byte WireGuard payload
- cookie reply: fixed 64-byte WireGuard payload
- transport-data: variable-length WireGuard payload

The key part of the fix is that WireGuard type-4 transport-data packets are restored from the actual GUT wire payload geometry instead of relying on mutable in-header metadata.

## Why

In a two-node relay topology with a fixed-peer side and a dynamic-peer side, handshakes could succeed, but reverse transport-data packets could fail to restore correctly.

The unstable part was relying on a GUT header byte as length metadata. In testing, the TC program could observe the expected value before redirect, while the emitted packet could still carry a different byte on the wire. The received wire payload length, however, remained stable.

## What changed

- Preserve canonical WireGuard handshake lengths for types 1, 2, and 3.
- Restore type-4 transport-data length by deriving it from the received GUT payload length.
- Keep transport-data handling variable-length.
- Drop malformed type-4 packets instead of passing corrupted UDP/WireGuard traffic further.
- Use explicit IPv4 UDP zero checksum for the final outer UDP packet to avoid stale CHECKSUM_PARTIAL/offload state corrupting the wire checksum on some VM/NAT paths.
- Use encapsulation-aware `bpf_skb_adjust_room()` flags for TC egress.

## Validation

Validated in a staged two-node kernel relay setup:

- fixed-peer side
- dynamic-peer side
- GUT obfuscation mode
- TC egress + XDP ingress
- WireGuard transport over GUT
- Internet egress through the dynamic-peer side

Validated ICMP payload sizes:

- 16 bytes
- 56 bytes
- 200 bytes
- 1200 bytes

All tested payload sizes completed with 0% packet loss after the fix.

## Notes

This PR intentionally does not include deployment scripts, environment-specific configuration, private topology details, debug maps, or diagnostic tracing.
